### PR TITLE
Fix alpine tag to 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.4
 MAINTAINER osawagiboy <osawagiboy@gmail.com>
 
 RUN apk --no-cache add clamav clamav-libunrar \


### PR DESCRIPTION
Hi,

I updated your Dockerfile to specify Alpine tag to prevent failure while building from old Alpine container:

```
sed: /etc/clamav/clamd.conf: No such file or directory
```
